### PR TITLE
Add Internet Explorer support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -80,13 +80,13 @@ Litepicker.prototype.enableModuleRanges = (self) => {
 
   const containerMain = self.picker.querySelector(`.${style.containerMain}`);
 
-  if (['bottom', 'right'].includes(opts.position)) {
+  if (opts.position == 'bottom' || opts.position == 'right') {
     containerMain.appendChild(block);
   } else {
-    containerMain.prepend(block);
+    containerMain.insertBefore(block, containerMain.firstChild);
   }
 
-  if (['top', 'bottom'].includes(opts.position)) {
+  if (opts.position == 'top' || opts.position == 'bottom') {
     block.classList.add(style.flexRow);
     containerMain.classList.add(style.flexColumn);
   } else {


### PR DESCRIPTION
After trying to use this addon on IE11, I found some incompatibilities.

### Array.prototype.includes()
According to MDN.com, IE does not support [Array.prototype.includes()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes#Browser_compatibility). So I changed it to a more simple string compare statement.

### ParentNode.prepend()
Internet Explorer also does not support the [ParentNode.prepend()](https://developer.mozilla.org/en-US/docs/Web/API/ParentNode/prepend#Browser_compatibility) function. However, this can easily be replaced by using [Node.insertBefore()](https://developer.mozilla.org/en-US/docs/Web/API/Node/insertBefore), which is supported.

After applying these changes, the module starts working normally on Internet Explorer.